### PR TITLE
Allow both lower and upper case X as checkmarks

### DIFF
--- a/checklist.js
+++ b/checklist.js
@@ -28,7 +28,7 @@ const axios = require('axios');
 		    let checked = false;
 		    while (lines[i].substring(0, 5) == '  - [' &&
 			   lines[i][6] == ']') {
-			if (lines[i][5] == 'x') {
+			if (lines[i][5] == 'x' || lines[i][5] == 'X') {
 			    checked = true;
 			}
 			++i;


### PR DESCRIPTION
The github UI is happy to accept both 'x' and 'X' as checkmarks, so we should probably do the same.  Without this, if someone uses 'X', the checklist checker will complain about no items being checked.

Signed-off-by: Tim Serong <tserong@suse.com>