### PR TITLE
Pin to sha1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
       with:
         python-version: "3.13"
     - name: Check


### PR DESCRIPTION
Instead of pinning to the major version tag, pin to its specific sha1.